### PR TITLE
Allow compose() implementations to have additional behaviors/metadata

### DIFF
--- a/src/compose-basic-tests.js
+++ b/src/compose-basic-tests.js
@@ -1,5 +1,4 @@
 import test from 'tape';
-import _ from 'lodash';
 
 module.exports = (compose) => {
 
@@ -12,60 +11,4 @@ module.exports = (compose) => {
 
     assert.end();
   });
-
-  test('compose.staticProperties', nest => {
-    ['staticProperties', 'staticDeepProperties'].forEach(descriptorName => {
-
-      nest.test(`...for descriptor with ${descriptorName}`, assert => {
-        const actual = compose({
-          [ descriptorName ]: {
-            a: 'a'
-          }
-        }, {
-          [ descriptorName ]: {
-            b: 'b'
-          }
-        }).compose[descriptorName];
-
-        const expected = {
-          a: 'a',
-          b: 'b'
-        };
-
-        assert.deepEqual(actual, expected,
-          `should compose ${ descriptorName } into descriptor`);
-
-        assert.end();
-      });
-
-      nest.test(`...for stamp with ${descriptorName}`, assert => {
-        const stamp = compose({
-          [ descriptorName ]: {
-            a: 'a'
-          }
-        }, {
-          [ descriptorName ]: {
-            b: 'b'
-          }
-        });
-
-        const actual = _.assign({}, {
-          a: stamp.a,
-          b: stamp.b
-        });
-
-        const expected = {
-          a: 'a',
-          b: 'b'
-        };
-
-        assert.deepEqual(actual, expected,
-          `should add ${ descriptorName } to stamp`);
-
-        assert.end();
-      });
-
-    });
-  });
-
 };

--- a/src/compose-tests.js
+++ b/src/compose-tests.js
@@ -5,10 +5,10 @@ module.exports = (compose) => {
 
   test('compose ignores non objects', assert => {
     const stamp = compose(0, 'a', null, undefined, {}, NaN, /regexp/);
-    const subject = _.values(stamp.compose).filter(_.negate(_.isEmpty)).length;
-    const expected = 0;
+    const subject = _.values(stamp.compose).filter(_.negate(_.isEmpty));
+    const expected = _.values(compose().compose);
 
-    assert.equal(subject, expected,
+    assert.deepEqual(subject, expected,
       'should not add any descriptor data');
 
     assert.end();

--- a/src/descriptor-tests.js
+++ b/src/descriptor-tests.js
@@ -1,8 +1,9 @@
 import test from 'tape';
+import _ from 'lodash';
 
 module.exports = (compose) => {
 
-  test('comopose function pojo (Plain Old JavaScript Object)', nest => {
+  test('compose function pojo (Plain Old JavaScript Object)', nest => {
     const objDescriptors = [
       'properties',
       'deepProperties',
@@ -63,10 +64,9 @@ module.exports = (compose) => {
         initializers: [a]
       }).compose.initializers;
 
-      const expected = [a];
 
-      assert.deepEqual(actual, expected,
-        'should create initializers descriptor');
+      assert.ok(_.includes(actual, a),
+        'should have initializers descriptor');
 
       assert.end();
     });

--- a/src/initializer-tests.js
+++ b/src/initializer-tests.js
@@ -43,10 +43,11 @@ module.exports = (compose) => {
   test('compose()', nest => {
 
     nest.test('...with no initializers', assert => {
+      const expected = _.size(compose().compose.initializers);
       const subject = compose({initializers: [0, 'a', null, undefined, {}, NaN, /regexp/]});
-      const initializers = subject.compose.initializers;
+      const actual = _.size(subject.compose.initializers);
 
-      assert.notOk(initializers && initializers.length,
+      assert.equal(actual, expected,
         'should not add any initializers');
 
       assert.end();
@@ -136,14 +137,6 @@ module.exports = (compose) => {
       };
       composable.compose.initializers = [
         function ({stampOption}, {instance, stamp, args}) {
-          const actual = {
-            correctThisValue: this === instance,
-            hasOptions: Boolean(stampOption),
-            hasInstance: Boolean(instance.instanceProps),
-            hasStamp: Boolean(stamp.compose),
-            argsLength: args.length === 3
-          };
-
           const expected = {
             correctThisValue: true,
             hasOptions: true,
@@ -151,6 +144,14 @@ module.exports = (compose) => {
             hasStamp: true,
             argsLength: true
           };
+
+          const actual = _.pick({
+            correctThisValue: this === instance,
+            hasOptions: Boolean(stampOption),
+            hasInstance: Boolean(instance.instanceProps),
+            hasStamp: Boolean(stamp.compose),
+            argsLength: args.length === 3
+          }, _.keys(expected));
 
           assert.deepEqual(actual, expected,
             'should call initializer with correct signature');
@@ -166,12 +167,12 @@ module.exports = (compose) => {
     nest.test('...with overrides in initializer', assert => {
       const stamp = buildInitializers();
 
-      const actual = compose(stamp)();
       const expected = {
         a: 'a',
         b: 'b',
         override: 'c'
       };
+      const actual = _.pick(compose(stamp)(), _.keys(expected));
 
       assert.deepEqual(actual, expected,
         'should apply initializers with last-in priority');
@@ -225,10 +226,10 @@ module.exports = (compose) => {
       ];
       const stamp = compose(composable);
 
-      const actual = compose(stamp)();
       const expected = {
         a: 'a'
       };
+      const actual = _.pick(compose(stamp)(), _.keys(expected));
 
       assert.deepEqual(actual, expected,
         'should use object instance as `this` inside initializers');
@@ -244,7 +245,7 @@ module.exports = (compose) => {
       stamp.compose.initializers = [0, 1, null, NaN, 'string', true, false];
 
       const actual = compose(stamp)();
-      const expected = {};
+      const expected = compose()();
 
       assert.deepEqual(actual, expected,
         'should avoid non functions in initializers array');
@@ -257,7 +258,7 @@ module.exports = (compose) => {
       stamp.compose.initializers = [() =>{}, 0, 1, null, NaN, 'string', true, false];
 
       const actual = stamp();
-      const expected = {};
+      const expected = compose()();
 
       assert.deepEqual(actual, expected,
         'should avoid non functions in initializers array');

--- a/src/merge-tests.js
+++ b/src/merge-tests.js
@@ -81,8 +81,8 @@ module.exports = (compose) => {
             deepProperties: {
               a: {b: 2}
             }
-          })();
-        const expected = {a: {b: 2}};
+          })().a;
+        const expected = {b: 2};
 
         assert.deepEqual(actual, expected,
           `${ prop } conflicts should be merged with last-in priority.`);
@@ -113,15 +113,13 @@ module.exports = (compose) => {
         const b = {
           foo: ['a', 'b', 'c']
         };
-        const expected = {
-          foo: ['a', 'b', 'c']
-        };
+        const expected = ['a', 'b', 'c'];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
-        t.notEqual(actual.foo, b.foo, 'array replacing object should be deep merged: c.foo !== b.foo');
+        t.notEqual(actual, b.foo, 'array replacing object should be deep merged: c.foo !== b.foo');
 
         t.end();
       });
@@ -136,17 +134,15 @@ module.exports = (compose) => {
           }
         };
         const expected = {
-          foo: {
-            bar: 'bam'
-          }
+          bar: 'bam'
         };
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
 
-        t.notEqual(actual.foo, b.foo, 'object replacing array should be deep merged: c.foo !== b.foo');
+        t.notEqual(actual, b.foo, 'object replacing array should be deep merged: c.foo !== b.foo');
 
         t.end();
       });
@@ -158,15 +154,13 @@ module.exports = (compose) => {
         const b = {
           foo: ['a', 'b', 'c']
         };
-        const expected = {
-          foo: [1, 2, 3, 'a', 'b', 'c']
-        };
+        const expected = [1, 2, 3, 'a', 'b', 'c'];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
-        t.notEqual(actual.foo, b.foo, 'array should be deep merged from right: c.foo === b.foo');
+        t.notEqual(actual, b.foo, 'array should be deep merged from right: c.foo === b.foo');
 
         t.end();
       });
@@ -178,11 +172,9 @@ module.exports = (compose) => {
         const b = {
           foo: 99
         };
-        const expected = {
-          foo: 99
-        };
+        const expected = 99;
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -197,11 +189,9 @@ module.exports = (compose) => {
         const b = {
           foo: [1, 2, 3]
         };
-        const expected = {
-          foo: [1, 2, 3]
-        };
+        const expected = [1, 2, 3];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -216,11 +206,9 @@ module.exports = (compose) => {
         const b = {
           foo: 'abc'
         };
-        const expected = {
-          foo: 'abc'
-        };
+        const expected = 'abc';
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -236,11 +224,9 @@ module.exports = (compose) => {
         const b = {
           foo: [1, 2, 3]
         };
-        const expected = {
-          foo: [1, 2, 3]
-        };
+        const expected = [1, 2, 3];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -255,11 +241,9 @@ module.exports = (compose) => {
         const b = {
           foo: true
         };
-        const expected = {
-          foo: true
-        };
+        const expected = true;
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -274,11 +258,9 @@ module.exports = (compose) => {
         const b = {
           foo: [1, 2, 3]
         };
-        const expected = {
-          foo: [1, 2, 3]
-        };
+        const expected = [1, 2, 3];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -293,11 +275,9 @@ module.exports = (compose) => {
         const b = {
           foo: false
         };
-        const expected = {
-          foo: false
-        };
+        const expected = false;
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -312,11 +292,9 @@ module.exports = (compose) => {
         const b = {
           foo: [1, 2, 3]
         };
-        const expected = {
-          foo: [1, 2, 3]
-        };
+        const expected = [1, 2, 3];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -332,11 +310,9 @@ module.exports = (compose) => {
         const b = {
           foo: null
         };
-        const expected = {
-          foo: null
-        };
+        const expected = null;
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -351,11 +327,9 @@ module.exports = (compose) => {
         const b = {
           foo: [1, 2, 3]
         };
-        const expected = {
-          foo: [1, 2, 3]
-        };
+        const expected = [1, 2, 3];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -368,11 +342,9 @@ module.exports = (compose) => {
         const b = {
           foo: [1, _, _.noop]
         };
-        const expected = {
-          foo: [1, _, _.noop]
-        };
+        const expected = [1, _, _.noop];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -387,11 +359,9 @@ module.exports = (compose) => {
         const b = {
           foo: undefined
         };
-        const expected = {
-          foo: [1, _, _.noop]
-        };
+        const expected = [1, _, _.noop];
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);
@@ -406,11 +376,9 @@ module.exports = (compose) => {
         const b = {
           foo: 42
         };
-        const expected = {
-          foo: 42
-        };
+        const expected = 42;
 
-        const actual = deepMerge(a, b);
+        const actual = deepMerge(a, b).foo;
         const expectedMsg = 'result expected  : ' + JSON.stringify(expected);
 
         t.deepEqual(actual, expected, expectedMsg);

--- a/src/property-descriptor-tests.js
+++ b/src/property-descriptor-tests.js
@@ -11,10 +11,7 @@ module.exports = (compose) => {
       enumerable: false
     };
     const b = _.assign({}, a);
-    const descriptors = {
-      a,
-      b
-    };
+    const descriptors = {a, b};
     return descriptors;
   };
 
@@ -41,7 +38,7 @@ module.exports = (compose) => {
         const actual = compose({
           propertyDescriptors: propertyValue
         })();
-        const expected = {};
+        const expected = compose()();
 
         assert.deepEqual(actual, expected,
           'should not any properties instances');
@@ -55,10 +52,10 @@ module.exports = (compose) => {
         const stamp = compose({
           staticPropertyDescriptors: propertyValue
         });
-        const actual = _.values(stamp.compose).filter(value => !_.isEmpty(value)).length;
-        const expected = 0;
+        const actual = _.values(stamp.compose).filter(value => !_.isEmpty(value));
+        const expected = _.values(compose().compose);
 
-        assert.equal(actual, expected,
+        assert.deepEqual(actual, expected,
           'should not add any descriptor data');
       });
 

--- a/src/stamp-tests.js
+++ b/src/stamp-tests.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+import _ from 'lodash';
 
 module.exports = (compose) => {
 
@@ -46,11 +47,11 @@ module.exports = (compose) => {
       };
       const stamp = compose(composable);
 
-      const actual = stamp();
       const expected = {
         a: 'a',
         b: 'b'
       };
+      const actual = _.pick(stamp(), _.keys(expected));
 
       assert.deepEqual(actual, expected,
         'should create properties');
@@ -85,11 +86,11 @@ module.exports = (compose) => {
       const stamp2 = compose(build('properties', 'b'));
       const finalStamp = stamp1.compose(stamp2);
 
-      const actual = finalStamp();
       const expected = {
         a: 'a',
         b: 'b'
       };
+      const actual = _.pick(finalStamp(), _.keys(expected));
 
       assert.deepEqual(actual, expected,
         'should use Stamp as base composable');

--- a/src/static-properties.js
+++ b/src/static-properties.js
@@ -1,0 +1,102 @@
+import test from 'tape';
+import _ from 'lodash';
+
+module.exports = (compose) => {
+
+  test('compose static properties with POJO', assert => {
+    const expected = {
+      a: 'a',
+      b: 'b'
+    };
+
+    const staticProperties = compose({
+      staticProperties: {
+        a: 'a'
+      }
+    }, {
+      staticProperties: {
+        b: 'b'
+      }
+    }).compose.staticProperties;
+    const actual = _.pick(staticProperties, _.keys(expected));
+
+    assert.deepEqual(actual, expected,
+      `should compose staticProperties into descriptor`);
+
+    assert.end();
+  });
+
+  test('compose static properties with stamp', assert => {
+    const expected = compose({
+      staticProperties: {
+        a: 'a',
+        b: 'b'
+      }
+    });
+
+    const staticProperties = compose({
+      staticProperties: {
+        a: 'a'
+      }
+    }, {
+      staticProperties: {
+        b: 'b'
+      }
+    }).compose.staticProperties;
+    const actual = _.pick(staticProperties, _.keys(expected));
+
+    assert.deepEqual(actual, expected,
+      `should compose staticProperties into descriptor`);
+
+    assert.end();
+  });
+
+  test('compose static deep properties with POJO', assert => {
+    const expected = {
+      a: 'a',
+      b: 'b'
+    };
+
+    const staticDeepProperties = compose({
+      staticDeepProperties: {
+        a: 'a'
+      }
+    }, {
+      staticDeepProperties: {
+        b: 'b'
+      }
+    }).compose.staticDeepProperties;
+    const actual = _.pick(staticDeepProperties, _.keys(expected));
+
+    assert.deepEqual(actual, expected,
+      `should compose staticDeepProperties into descriptor`);
+
+    assert.end();
+  });
+
+  test('compose static deep properties with stamp', assert => {
+    const expected = compose({
+      staticDeepProperties: {
+        a: 'a',
+        b: 'b'
+      }
+    });
+
+    const staticDeepProperties = compose({
+      staticDeepProperties: {
+        a: 'a'
+      }
+    }, {
+      staticDeepProperties: {
+        b: 'b'
+      }
+    }).compose.staticDeepProperties;
+    const actual = _.pick(staticDeepProperties, _.keys(expected));
+
+    assert.deepEqual(actual, expected,
+      `should compose staticDeepProperties into descriptor`);
+
+    assert.end();
+  });
+
+};


### PR DESCRIPTION
It is allowed to add arbitrary data to property descriptors. The `check-compose` often was expecting to have 0 added data.

This PR makes sure that `compose()` implementations are not limited to add any additional metadata.
